### PR TITLE
feat: Ahora el botón de descarga no se oculta en displays verticales

### DIFF
--- a/src/components/TableExamenes.astro
+++ b/src/components/TableExamenes.astro
@@ -58,7 +58,7 @@ const { examenes } = Astro.props;
                                 href={examen.download_url}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                class="mx-2 w-full max-md:hidden"
+                                class="mx-2 w-full"
                             >
                                 <Button variant="outline" className="h-8 w-full">
                                     <Icon name="carbon:download" size={20} />


### PR DESCRIPTION

# Descripción
Se quitó `max-sm hidden` de la clase del botón de descarga en la fila de un examén, para permitir que se muestre siempre.

## Problema solucionado
Cómo puse en el issue: https://github.com/ramiro-l/Examenes-Viejos-Web/issues/5
En los celulares android no se admite preview de pdf's en el navegador default. Agregar el botón de descarga de forma
que no se oculte en los celulares con display en vertical, parece la mejor solución  para el problema.


## Capturas de pantalla <!-- (no es super necesario) -->
![image](https://github.com/user-attachments/assets/17670803-470c-4f37-a98e-d9c95f224ae4)

## Comprobación de cambios

-   [x ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
-   [x ] He probado estos cambios en mobile y desktop.
